### PR TITLE
Rotsw Implemented and tested.

### DIFF
--- a/classes/CMakeLists.txt
+++ b/classes/CMakeLists.txt
@@ -1,2 +1,11 @@
 # Class Libraries -- Add .cpp file from each class here
 add_library(Classes ExampleClass.cpp RotSW.cpp RotSW.h)
+
+include($ENV{PICO_SDK_PATH}/external/pico_sdk_import.cmake)
+
+target_link_libraries(Classes
+        pico_stdlib
+        hardware_pwm
+        hardware_gpio
+        hardware_i2c
+)

--- a/classes/RotSW.cpp
+++ b/classes/RotSW.cpp
@@ -1,7 +1,6 @@
 #include "RotSW.h"
 
-//
-void RotSW::InterruptHandler(uint gpio, uint32_t event_mask)
+void RotSW::interruptHandler(uint gpio, uint32_t event_mask)
 {
     RotSW_event event;
     if (gpio == mRotAPin) {
@@ -13,17 +12,37 @@ void RotSW::InterruptHandler(uint gpio, uint32_t event_mask)
                 event = gpio_get(mRotBPin) ? COUNTER_CLOCKWISE : CLOCKWISE;
                 break;
             default:
-                event = NOTHING;
+                event = WEIRD;
         }
     } else {
-        event = PRESS;
+        switch (event_mask) {
+            case GPIO_IRQ_EDGE_RISE:
+                mPrevRise = time_us_64();
+                event = NO_EVENT;
+                break;
+            case GPIO_IRQ_EDGE_FALL:
+                uint64_t now = time_us_64();
+                if (now - mPrevRise > PRESS_DEBOUNCE_DELAY_US) {
+                    event = PRESS;
+                } else {
+                    event = NO_EVENT;
+                }
+        }
     }
     mEvents.push(event);
 }
 
+// Initialize static members
+uint RotSW::mPressPin;
+uint64_t RotSW::mPrevRise;
+uint RotSW::mRotAPin;
+uint RotSW::mRotBPin;
+std::queue<RotSW_event> RotSW::mEvents;
+
 RotSW::RotSW(uint press_pin, uint rot_A_pin, uint rot_B_pin)
 {
     mPressPin = press_pin;
+    mPrevRise = 0;
     mRotAPin = rot_A_pin;
     mRotBPin = rot_B_pin;
 
@@ -32,24 +51,24 @@ RotSW::RotSW(uint press_pin, uint rot_A_pin, uint rot_B_pin)
     gpio_init(mRotBPin);
 
     gpio_set_irq_enabled_with_callback(mPressPin,
-                                       GPIO_IRQ_EDGE_FALL,
+                                       GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL,
                                        true,
-                                       InterruptHandler);
+                                       interruptHandler);
     gpio_set_irq_enabled_with_callback(mRotAPin,
                                        GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL,
                                        true,
-                                       InterruptHandler);
+                                       interruptHandler);
 }
 
 
-RotSW::operator RotSW_event()
+RotSW_event RotSW::getEvent()
 {
     RotSW_event event;
     if (!mEvents.empty()) {
         event = mEvents.front();
         mEvents.pop();
     } else {
-        event = NOTHING;
+        event = NO_EVENT;
     }
     return event;
 }

--- a/classes/RotSW.h
+++ b/classes/RotSW.h
@@ -3,17 +3,22 @@
 
 #include <cstdio>
 #include <queue>
+#include "pico/stdlib.h"
+
+#define PRESS_DEBOUNCE_DELAY_US 50000
 
 typedef enum RotSW_enum {
-    NOTHING,
+    NO_EVENT,
     PRESS,
     CLOCKWISE,
     COUNTER_CLOCKWISE,
+    WEIRD
 } RotSW_event;
 
 class RotSW {
 private:
     static uint mPressPin;
+    static uint64_t mPrevRise; // used for debouncing stutter
     static uint mRotAPin;
     static uint mRotBPin;
     static std::queue<RotSW_event> mEvents;
@@ -21,9 +26,9 @@ public:
     explicit RotSW(uint press_pin0 = 12,
                    uint rot_A_pin0 = 11,
                    uint rot_B_pin0 = 10);
-    static void InterruptHandler(uint gpio,
+    static void interruptHandler(uint gpio,
                                  uint32_t event_mask);
-    explicit operator RotSW_event();
+    RotSW_event getEvent();
 };
 
 #endif //PICO_MODBUS_ROTSW_H


### PR DESCRIPTION
Interrupt handler checks for both rotation and press,
saves the events in its queue.
I applied a 50 ms debounce to the press, cuz the gnob is erratic.